### PR TITLE
chore: add repo configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_size = 4
+indent_style = tab
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text eol=lf
+
+*.png binary
+*.jpg binary
+*.gif binary
+*.webp binary


### PR DESCRIPTION
Adding a .gitattributes and .editorconfig ensures that different environments handle and display the code consistently.

Also, treating images/gifs as binary prevents them from being corrupted due to crlf vs lf conversions.